### PR TITLE
gerrit: Use a Gerrit label instead of hashtag for autosubmit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ await CI feedback on a rebased changeset, then one clicks submit, and
 effectively makes everybody else rebase again. `gerrit-queue` is meant to
 remove these races to master.
 
-Developers can add a specific tag `submit_me` to all changesets in a series,
+Developers can set the `Autosubmit` label to `+1` on all changesets in a series,
 and if all preconditions on are met ("submittable" in gerrit speech, this
 usually means passing CI and passing Code Review), `gerrit-queue` takes care of
 rebasing and submitting it to master

--- a/README.md
+++ b/README.md
@@ -8,10 +8,35 @@ await CI feedback on a rebased changeset, then one clicks submit, and
 effectively makes everybody else rebase again. `gerrit-queue` is meant to
 remove these races to master.
 
-Developers can set the `Autosubmit` label to `+1` on all changesets in a series,
-and if all preconditions on are met ("submittable" in gerrit speech, this
-usually means passing CI and passing Code Review), `gerrit-queue` takes care of
-rebasing and submitting it to master
+Developers can set the `Autosubmit` customized label to `+1` on all changesets
+in a series, and if all preconditions on are met ("submittable" in gerrit
+speech, this usually means passing CI and passing Code Review),
+`gerrit-queue` takes care of rebasing and submitting it to master.
+
+Refer to the [Customized Label Gerrit docs](https://gerrit-review.googlesource.com/Documentation/config-labels.html#label_custom)
+on how to create the `Autosubmit` label and configure permissions, but
+something like the following in your projects `project.config` should suffice:
+
+```
+[access "refs/*"]
+  # […]
+	#
+	# Set exclusive because only the change owner should be able to do this:
+	exclusiveGroupPermissions = label-Autosubmit
+	label-Autosubmit = +0..+1 group Change Owner
+[label "Autosubmit"]
+	function = NoOp
+	value = 0 Submit manually
+	value = +1 Submit automatically
+	allowPostSubmit = false
+	copyAnyScore = true
+	defaultValue = 0
+```
+
+Note that if a setup uses `rules.pl`, the label will not be rendered unless it
+is configured as `may(_)` in the rules.
+
+See [TVL CL 4241](https://cl.tvl.fyi/c/depot/+/4241) for an example.
 
 ## How it works
 Gerrit only knows about Changesets (and some relations to other changesets),

--- a/gerrit/changeset.go
+++ b/gerrit/changeset.go
@@ -16,8 +16,8 @@ type Changeset struct {
 	Number          int
 	Verified        int
 	CodeReviewed    int
+	Autosubmit      int
 	Submittable     bool
-	HashTags        []string
 	CommitID        string
 	ParentCommitIDs []string
 	OwnerName       string
@@ -32,8 +32,8 @@ func MakeChangeset(changeInfo *goGerrit.ChangeInfo) *Changeset {
 		Number:          changeInfo.Number,
 		Verified:        labelInfoToInt(changeInfo.Labels["Verified"]),
 		CodeReviewed:    labelInfoToInt(changeInfo.Labels["Code-Review"]),
+		Autosubmit:      labelInfoToInt(changeInfo.Labels["Autosubmit"]),
 		Submittable:     changeInfo.Submittable,
-		HashTags:        changeInfo.Hashtags,
 		CommitID:        changeInfo.CurrentRevision, // yes, this IS the commit ID.
 		ParentCommitIDs: getParentCommitIDs(changeInfo),
 		OwnerName:       changeInfo.Owner.Name,
@@ -41,15 +41,13 @@ func MakeChangeset(changeInfo *goGerrit.ChangeInfo) *Changeset {
 	}
 }
 
-// HasTag returns true if a Changeset has the given tag.
-func (c *Changeset) HasTag(tag string) bool {
-	hashTags := c.HashTags
-	for _, hashTag := range hashTags {
-		if hashTag == tag {
-			return true
-		}
-	}
-	return false
+// IsAutosubmit returns true if the changeset is intended to be
+// automatically submitted by gerrit-queue.
+//
+// This is determined by the Change Owner setting +1 on the
+// "Autosubmit" label.
+func (c *Changeset) IsAutosubmit() bool {
+	return c.Autosubmit == 1
 }
 
 // IsVerified returns true if the changeset passed CI,

--- a/gerrit/changeset.go
+++ b/gerrit/changeset.go
@@ -84,6 +84,7 @@ func FilterChangesets(changesets []*Changeset, f func(*Changeset) bool) []*Chang
 }
 
 // labelInfoToInt converts a goGerrit.LabelInfo to -2…+2 int
+// its behaviour for other labels is undefined.
 func labelInfoToInt(labelInfo goGerrit.LabelInfo) int {
 	if labelInfo.Recommended.AccountID != 0 {
 		return 2

--- a/gerrit/changeset_test.go
+++ b/gerrit/changeset_test.go
@@ -1,0 +1,55 @@
+package gerrit
+
+import (
+	"testing"
+
+	goGerrit "github.com/andygrunwald/go-gerrit"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsAutosubmit(t *testing.T) {
+	emptyChangeInfo := &goGerrit.ChangeInfo{}
+	assert.Equal(t, false, MakeChangeset(emptyChangeInfo).IsAutosubmit(), "A changeset without the Autosubmit label present shouldn't be autosubmittable")
+
+	// +1
+	changeInfoWithAutosubmitLabelSet := &goGerrit.ChangeInfo{
+		Labels: map[string]goGerrit.LabelInfo{
+			"Autosubmit": {
+				Approved: goGerrit.AccountInfo{AccountID: 1},
+			},
+		},
+	}
+	assert.Equal(t, true, MakeChangeset(changeInfoWithAutosubmitLabelSet).IsAutosubmit(), "Autosubmit label set to +1 should be autosubmittable")
+
+	// ensure some common label values don't trigger autosubmit. We only trigger on a "+1"
+
+	// +2
+	changeInfoWithAutosubmitLabelSetToPlusTwo := &goGerrit.ChangeInfo{
+		Labels: map[string]goGerrit.LabelInfo{
+			"Autosubmit": {
+				Recommended: goGerrit.AccountInfo{AccountID: 1},
+			},
+		},
+	}
+	assert.Equal(t, false, MakeChangeset(changeInfoWithAutosubmitLabelSetToPlusTwo).IsAutosubmit(), "Autosubmit label set to +2 should not be autosubmittable")
+
+	// -1
+	changeInfoWithAutosubmitLabelSetToMinusOne := &goGerrit.ChangeInfo{
+		Labels: map[string]goGerrit.LabelInfo{
+			"Autosubmit": {
+				Disliked: goGerrit.AccountInfo{AccountID: 1},
+			},
+		},
+	}
+	assert.Equal(t, false, MakeChangeset(changeInfoWithAutosubmitLabelSetToMinusOne).IsAutosubmit(), "Autosubmit label set to -1 should not be autosubmittable")
+
+	// -2
+	changeInfoWithAutosubmitLabelSetToMinusTwo := &goGerrit.ChangeInfo{
+		Labels: map[string]goGerrit.LabelInfo{
+			"Autosubmit": {
+				Rejected: goGerrit.AccountInfo{AccountID: 1},
+			},
+		},
+	}
+	assert.Equal(t, false, MakeChangeset(changeInfoWithAutosubmitLabelSetToMinusTwo).IsAutosubmit(), "Autosubmit label set to -2 should not be autosubmittable")
+}

--- a/gerrit/client.go
+++ b/gerrit/client.go
@@ -26,7 +26,6 @@ type IClient interface {
 	GetChangesetURL(changeset *Changeset) string
 	SubmitChangeset(changeset *Changeset) (*Changeset, error)
 	RebaseChangeset(changeset *Changeset, ref string) (*Changeset, error)
-	RemoveTag(changeset *Changeset, tag string) (*Changeset, error)
 	ChangesetIsRebasedOnHEAD(changeset *Changeset) bool
 	SerieIsRebasedOnHEAD(serie *Serie) bool
 	FilterSeries(filter func(s *Serie) bool) []*Serie
@@ -159,21 +158,6 @@ func (c *Client) RebaseChangeset(changeset *Changeset, ref string) (*Changeset, 
 		return changeset, err
 	}
 	return c.fetchChangeset(changeInfo.ChangeID)
-}
-
-// RemoveTag removes the submit queue tag from a changeset and updates gerrit
-// we never add, that's something users should do in the GUI.
-func (c *Client) RemoveTag(changeset *Changeset, tag string) (*Changeset, error) {
-	hashTags := changeset.HashTags
-	newHashTags := []string{}
-	for _, hashTag := range hashTags {
-		if hashTag != tag {
-			newHashTags = append(newHashTags, hashTag)
-		}
-	}
-	// TODO: implement setting hashtags api in go-gerrit and use here
-	// https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#set-hashtags
-	return changeset, nil
 }
 
 // GetBaseURL returns the gerrit base URL

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/andygrunwald/go-gerrit v0.0.0-20190825170856-5959a9bf9ff8
 	github.com/apex/log v1.1.1
 	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli v1.22.1
 )

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,9 @@ github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUr
 github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h1:SnhjPscd9TpLiy1LpzGSKh3bXCfxxXuqd9xmQJy3slM=
 github.com/smartystreets/gunit v1.0.0/go.mod h1:qwPWnhz6pn0NnRBP++URONOVyNkPyr4SauJk4cUOwJs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
 github.com/tj/go-elastic v0.0.0-20171221160941-36157cbbebc2/go.mod h1:WjeM0Oo1eNAjXGDx2yma7uG2XoyRZTq1uv3M/o7imD0=
 github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPfx6jb1bBgRFjl5lytqVqZXEaeqWP8lTEao=
@@ -62,8 +63,11 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 )
 
 func main() {
-	var URL, username, password, projectName, branchName, submitQueueTag string
+	var URL, username, password, projectName, branchName string
 	var fetchOnly bool
 	var triggerInterval int
 
@@ -62,13 +62,6 @@ func main() {
 			Destination: &branchName,
 			Value:       "master",
 		},
-		cli.StringFlag{
-			Name:        "submit-queue-tag",
-			Usage:       "the tag used to submit something to the submit queue",
-			EnvVar:      "SUBMIT_QUEUE_TAG",
-			Destination: &submitQueueTag,
-			Value:       "submit_me",
-		},
 		cli.IntFlag{
 			Name:        "trigger-interval",
 			Usage:       "How often we should trigger ourselves (interval in seconds)",
@@ -100,7 +93,7 @@ func main() {
 		}
 		log.Infof("Successfully connected to gerrit at %s", URL)
 
-		runner := submitqueue.NewRunner(l, gerrit, submitQueueTag)
+		runner := submitqueue.NewRunner(l, gerrit)
 
 		handler := frontend.MakeFrontend(rotatingLogHandler, gerrit, runner)
 

--- a/submitqueue/runner.go
+++ b/submitqueue/runner.go
@@ -20,26 +20,24 @@ type Runner struct {
 	wipSerie         *gerrit.Serie
 	logger           *log.Logger
 	gerrit           *gerrit.Client
-	submitQueueTag   string // the tag used to submit something to the submit queue
 }
 
 // NewRunner creates a new Runner struct
-func NewRunner(logger *log.Logger, gerrit *gerrit.Client, submitQueueTag string) *Runner {
+func NewRunner(logger *log.Logger, gerrit *gerrit.Client) *Runner {
 	return &Runner{
-		logger:         logger,
-		gerrit:         gerrit,
-		submitQueueTag: submitQueueTag,
+		logger: logger,
+		gerrit: gerrit,
 	}
 }
 
 // isAutoSubmittable determines if something could be autosubmitted, potentially requiring a rebase
 // for this, it needs to:
-//  * have the auto-submit label
+//  * have the "Autosubmit" label set to +1
 //  * have gerrit's 'submittable' field set to true
 // it doesn't check if the series is rebased on HEAD
 func (r *Runner) isAutoSubmittable(s *gerrit.Serie) bool {
 	for _, c := range s.ChangeSets {
-		if c.Submittable != true || !c.HasTag(r.submitQueueTag) {
+		if c.Submittable != true || !c.IsAutosubmit() {
 			return false
 		}
 	}


### PR DESCRIPTION
This moves to using a Gerrit label ('Autosubmit') with boolean values
for determining whether a developer wants to have a change
automatically submitted.

See also https://cl.tvl.fyi/c/depot/+/4172